### PR TITLE
41 - ciサーバでeslintのチェックを行えるようにする

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,17 @@ jobs:
             - node_modules
           key: v1-dependencies-{{ checksum "package.json" }}
 
+      - run:
+          name: "ESLint"
+          command: |
+            mkdir -p ~/reports
+            yarn eslint ./src/ --format junit --output-file ~/reports/eslint.xml
+          when: always
+      - store_test_results:
+          path: ~/reports
+      - store_artifacts:
+          path: ~/reports
+
       # run tests!
       - run:
           name: jest tests

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+/node_modules/

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,10 +22,6 @@ module.exports = {
             'error',
             2
         ],
-        'linebreak-style': [
-            'error',
-            'unix'
-        ],
         'quotes': [
             'error',
             'single'


### PR DESCRIPTION
# 説明
今まで、eslintのエラーはPRのときに指摘されていて、すごく無駄だったので、Ciサーバでけるようにしたい。

# issue
#41 