### PR TITLE
75 - nav barが複数画面で消えてる

### DIFF
--- a/src/components/Router.js
+++ b/src/components/Router.js
@@ -68,7 +68,6 @@ const RouterComponent = ({ pageMoved, fetchArticles }) => (
           key='mainwithtabs'
           tabs
           showLabel={false}
-          hideNavBar={true}
           panHandlers={null}
           activeBackgroundColor='#fff'
           activeTintColor='#2C9D46'


### PR DESCRIPTION
## 説明
タブありのシーンでついてた'hideNavBar'を無くす。

## Issue
#75 