### PR TITLE
98 ブックマークが無いときにエラーが出ない

### DIFF
--- a/src/actions/ArticleActions.js
+++ b/src/actions/ArticleActions.js
@@ -129,7 +129,7 @@ export const fetchBookmarks = () => {
       return data;
     });
 
-    if (articles) {
+    if (articles[0]) {
       dispatch({
         type: FETCH_ARTICLES_SUCCESS,
         payload: articles,


### PR DESCRIPTION
問題
ブックマーク０件にも関わらず、条件式でtrueになっていて、エラーが出ない
解決策
正しくエラーになるよう、条件式を修正